### PR TITLE
feat: implement `Build` for `Stream`s

### DIFF
--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -16,6 +16,8 @@
 //! Livre can represent those as generic [`HashMap`](std::collections::HashMap)s,
 //! or extract them as structured types using the [`FromRawDict`] trait.
 //!
+//! Using this trait instead of [`Extract`] directly lets us use more complex extraction patterns.
+//!
 //! ## Derivability
 //!
 //! Through the [`livre_derive`] helper crate, Livre provides (and uses) a derive macro

--- a/src/extraction/special/stream.rs
+++ b/src/extraction/special/stream.rs
@@ -1,6 +1,6 @@
 use winnow::{
     ascii::{line_ending, multispace0},
-    combinator::trace,
+    combinator::{delimited, trace},
     error::{ContextError, ErrMode},
     token::take,
     BStr, PResult, Parser,
@@ -9,23 +9,82 @@ use winnow::{
 use crate::{
     extraction::{extract, Extract, FromRawDict},
     filtering::{Filter, Filtering},
+    follow_refs::{Build, BuildFromRawDict, Builder, Built},
 };
 
 use super::{MaybeArray, Nil, RawDict};
 
 #[derive(Debug, PartialEq, Eq, FromRawDict)]
-struct StreamDict<T> {
-    // FIXME: the length of a PDF stream is in fact an OptRef... This allows processors to write
-    // the stream without knowing its size in advance.
-    // Be that as it may, this is a failure case for the time being.
+pub struct StreamConfig {
     length: usize,
     #[livre(from = MaybeArray<Filter>, default)]
     filter: Vec<Filter>,
+}
+
+impl Parser<&BStr, Vec<u8>, ContextError> for StreamConfig {
+    fn parse_next(&mut self, input: &mut &BStr) -> PResult<Vec<u8>> {
+        let content = trace(
+            "livre-stream-content",
+            delimited(
+                (multispace0, b"stream", line_ending),
+                take(self.length),
+                (multispace0, b"endstream"),
+            ),
+        )
+        .parse_next(input)?;
+
+        self.filter
+            .decode(content)
+            .map_err(|_| ErrMode::Cut(ContextError::new()))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, FromRawDict)]
+struct StreamDict<T> {
+    #[livre(flatten)]
+    config: StreamConfig,
     #[livre(flatten)]
     structured: T,
 }
 
+impl<'de> BuildFromRawDict<'de> for StreamConfig {
+    fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    where
+        B: Builder<'de>,
+    {
+        let Built(length) = dict
+            .pop_and_build(&b"Length".into(), builder)
+            .ok_or(ErrMode::Backtrack(ContextError::new()))??;
+
+        let Built(filter) = dict
+            .pop_and_build(&b"Filter".into(), builder)
+            .ok_or(ErrMode::Backtrack(ContextError::new()))??;
+
+        Ok(Self { length, filter })
+    }
+}
+
+impl<'de, T> BuildFromRawDict<'de> for StreamDict<T>
+where
+    T: BuildFromRawDict<'de>,
+{
+    fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    where
+        B: Builder<'de>,
+    {
+        let config = StreamConfig::build_from_raw_dict(dict, builder)?;
+        let structured = T::build_from_raw_dict(dict, builder)?;
+
+        Ok(Self { config, structured })
+    }
+}
+
 /// A PDF object that stores arbitrary content, as well as some (optional) structured data.
+///
+/// PDF streams can be used to:
+///
+/// - store page content (any dictionary data may contain indirect objects)
+/// - store cross-references (no references)
 #[derive(Debug, PartialEq, Clone)]
 pub struct Stream<T> {
     pub structured: T,
@@ -41,20 +100,11 @@ where
         trace("livre-stream-dict", move |i: &mut &'de BStr| {
             let mut dict: RawDict = extract(i)?;
             let StreamDict {
-                length,
-                filter,
+                mut config,
                 structured,
             } = StreamDict::from_raw_dict(&mut dict)?;
 
-            (multispace0, b"stream", line_ending).parse_next(i)?;
-
-            let content = take(length).parse_next(i)?;
-
-            (multispace0, b"endstream").parse_next(i)?;
-
-            let content = filter
-                .decode(content)
-                .map_err(|_| ErrMode::Cut(ContextError::new()))?;
+            let content = config.parse_next(i)?;
 
             Ok((
                 Self {
@@ -81,6 +131,32 @@ where
     }
 }
 
+impl<'de, T> Build<'de> for Stream<T>
+where
+    T: BuildFromRawDict<'de>,
+{
+    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    where
+        B: Builder<'de>,
+    {
+        trace("livre-stream", move |i: &mut &'de BStr| {
+            let mut dict: RawDict = extract(i)?;
+            let StreamDict {
+                mut config,
+                structured,
+            } = StreamDict::build_from_raw_dict(&mut dict, builder)?;
+
+            let content = config.parse_next(i)?;
+
+            Ok(Self {
+                structured,
+                content,
+            })
+        })
+        .parse_next(input)
+    }
+}
+
 impl Extract<'_> for Stream<()> {
     fn extract(input: &mut &'_ BStr) -> PResult<Self> {
         let Stream {
@@ -92,6 +168,29 @@ impl Extract<'_> for Stream<()> {
             structured: (),
             content,
         })
+    }
+}
+
+impl<'de> Build<'de> for Stream<()> {
+    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    where
+        B: Builder<'de>,
+    {
+        trace("livre-stream", move |i: &mut &'de BStr| {
+            let mut dict: RawDict = extract(i)?;
+            let StreamDict {
+                mut config,
+                structured: Nil,
+            } = StreamDict::build_from_raw_dict(&mut dict, builder)?;
+
+            let content = config.parse_next(i)?;
+
+            Ok(Self {
+                structured: (),
+                content,
+            })
+        })
+        .parse_next(input)
     }
 }
 
@@ -108,13 +207,22 @@ mod tests {
     use super::*;
 
     #[rstest]
-    #[case(b"<</Length 2/SomeOtherKey/Test>>", StreamDict{length: 2, filter: vec![], structured: Nil})]
-    #[case(b"<</Length 42>>", StreamDict{length: 42, filter: vec![], structured: Nil})]
-    #[case(b"<<  /SomeRandomKey (some text...)/Length 42>>", StreamDict{length: 42, filter: vec![], structured: Nil})]
-    fn stream_dict(#[case] input: &[u8], #[case] expected: StreamDict<Nil>) {
+    #[case(b"<</Length 2/SomeOtherKey/Test>>", StreamConfig{length: 2, filter: vec![]})]
+    #[case(b"<</Length 42>>", StreamConfig{length: 42, filter: vec![]})]
+    #[case(b"<<  /SomeRandomKey (some text...)/Length 42>>", StreamConfig{length: 42, filter: vec![]})]
+    fn stream_config(#[case] input: &[u8], #[case] expected: StreamConfig) {
         let result = extract(&mut input.as_ref()).unwrap();
         assert_eq!(expected, result);
     }
+
+    //#[rstest]
+    //#[case(b"<</Length 2/SomeOtherKey/Test>>", StreamDict{length: 2, filter: vec![], structured: Nil})]
+    //#[case(b"<</Length 42>>", StreamDict{length: 42, filter: vec![], structured: Nil})]
+    //#[case(b"<<  /SomeRandomKey (some text...)/Length 42>>", StreamDict{length: 42, filter: vec![], structured: Nil})]
+    //fn stream_dict(#[case] input: &[u8], #[case] expected: StreamDict<Nil>) {
+    //    let result = extract(&mut input.as_ref()).unwrap();
+    //    assert_eq!(expected, result);
+    //}
 
     #[derive(Debug, PartialEq, FromRawDict)]
     struct TestStruct {

--- a/src/extraction/special/stream.rs
+++ b/src/extraction/special/stream.rs
@@ -98,7 +98,7 @@ where
 ///
 /// PDF streams can be used to:
 ///
-/// - store page content (any dictionary data may contain indirect objects)
+/// - store page content (any dictionary field may contain point to an indirect object)
 /// - store cross-references (no references)
 ///
 /// In Livre, PDF-specific structured properties are considered implementation details, and an

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -9,7 +9,10 @@ use winnow::{
 
 use flate2::read::ZlibDecoder;
 
-use crate::extraction::{extract, Extract, Name};
+use crate::{
+    extraction::{extract, Extract, Name},
+    follow_refs::{Build, Builder},
+};
 
 /// Main filter objects, that represents any kind of PDF filter.
 ///
@@ -53,6 +56,15 @@ impl Extract<'_> for Filter {
             }
             _ => Err(ErrMode::Backtrack(ContextError::new())),
         }
+    }
+}
+
+impl<'de> Build<'de> for Filter {
+    fn build<B>(input: &mut &'_ BStr, _builder: &B) -> PResult<Self>
+    where
+        B: Builder<'de>,
+    {
+        extract(input)
     }
 }
 

--- a/src/follow_refs/build.rs
+++ b/src/follow_refs/build.rs
@@ -9,7 +9,7 @@ use winnow::{
 };
 
 use crate::extraction::{
-    extract, Extract, HexadecimalString, Id, LiteralString, MaybeArray, Name, Object, Rectangle,
+    extract, HexadecimalString, Id, LiteralString, MaybeArray, Name, Object, Rectangle,
 };
 
 use super::{Builder, BuilderParser, Built};
@@ -18,7 +18,9 @@ use super::{Builder, BuilderParser, Built};
 /// extraction logic to follow references.
 ///
 /// Although most `Extract` types trivially implement `Build`, we cannot use a blanket
-/// implementation because of the [`OptRef`](crate::extraction::OptRef) type.
+/// implementation because of the [`OptRef`](crate::extraction::OptRef) type. Moreover,
+/// this would disallow implementing `Build` for [`BuildFromRawDict`](super::BuildFromRawDict),
+/// because the compiler would mark them as competing implementations.
 pub trait Build<'de>: Sized {
     /// Build an object that rely on a reference, which would be instantiated with the help of the
     /// supplied `builder`.

--- a/src/follow_refs/build.rs
+++ b/src/follow_refs/build.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, ptr};
+use std::fmt::Debug;
 
 use paste::paste;
 
@@ -25,9 +25,9 @@ pub trait Build<'de>: Sized {
     /// Build an object that rely on a reference, which would be instantiated with the help of the
     /// supplied `builder`.
     ///
-    /// The [`Build`] trait, like the [`Extract`] trait, is a linear parser above all, hence we
-    /// supply an `input`. References found during parsing, if any, are first parsed as such, and
-    /// then instantiated by the `builder`.
+    /// The [`Build`] trait, like the [`Extract`](crate::extraction::Extract) trait, is a linear
+    /// parser above all, hence we supply an `input`. References found during parsing, if any,
+    /// are first parsed as such, and then instantiated by the `builder`.
     fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
     where
         B: Builder<'de>;

--- a/src/follow_refs/build.rs
+++ b/src/follow_refs/build.rs
@@ -1,4 +1,4 @@
-use std::ptr;
+use std::{fmt::Debug, ptr};
 
 use paste::paste;
 
@@ -12,7 +12,7 @@ use crate::extraction::{
     extract, Extract, HexadecimalString, Id, LiteralString, MaybeArray, Name, Object, Rectangle,
 };
 
-use super::{Builder, BuilderParser};
+use super::{Builder, BuilderParser, Built};
 
 /// Generalisation on the [`Extract`](crate::extraction::Extract) trait, which allows the
 /// extraction logic to follow references.
@@ -66,7 +66,11 @@ where
     where
         B: Builder<'de>,
     {
-        alt((builder.as_parser().map(Some), b"null".map(|_| None))).parse_next(input)
+        alt((
+            builder.as_parser().map(|Built(value)| Some(value)),
+            b"null".map(|_| None),
+        ))
+        .parse_next(input)
     }
 }
 
@@ -81,7 +85,7 @@ where
         trace(
             "livre-vec",
             alt((
-                builder.as_parser().map(|value| vec![value]),
+                builder.as_parser().map(|Built(value)| vec![value]),
                 builder.as_parser(),
             )),
         )
@@ -102,7 +106,10 @@ where
             "livre-vec",
             delimited(
                 b'[',
-                repeat(0.., preceded(multispace0, builder.as_parser())),
+                repeat(
+                    0..,
+                    preceded(multispace0, builder.as_parser().map(|Built(item)| item)),
+                ),
                 (multispace0, b']'),
             ),
         )
@@ -112,7 +119,7 @@ where
 
 impl<'de, T, const N: usize> Build<'de> for [T; N]
 where
-    T: Build<'de>,
+    T: Build<'de> + Debug,
 {
     fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
     where
@@ -122,27 +129,15 @@ where
             concat!("livre-{N}-array"),
             delimited(
                 b'[',
-                repeat(N, preceded(multispace0, builder.as_parser())),
+                repeat(
+                    N,
+                    preceded(multispace0, builder.as_parser().map(|Built(value)| value)),
+                ),
                 (multispace0, b']'),
             ),
         )
-        .map(|mut vec: Vec<T>| {
-            // NOTE: the following transformation from a `Vec` (of the correct length)
-            // to an array is taken from
-            // <https://doc.rust-lang.org/1.80.1/src/alloc/vec/mod.rs.html#3540>
-            // This allows to remove the Debug trait bound...
-            // FIXME: find an alternative design that either a) does not use unsafe and/or b) does
-            // not allocate a `Vec` to begin with.
-
-            // SAFETY: `.set_len(0)` is always sound.
-            unsafe { vec.set_len(0) };
-
-            // SAFETY: A `Vec`'s pointer is always aligned properly, and
-            // the alignment the array needs is the same as the items.
-            // We checked earlier that we have sufficient items.
-            // The items will not double-drop as the `set_len`
-            // tells the `Vec` not to also drop them.
-            unsafe { ptr::read(vec.as_ptr() as *const [T; N]) }
+        .map(|values: Vec<T>| {
+            <[T; N]>::try_from(values).expect("correct number of elements by construction")
         })
         .parse_next(input)
     }

--- a/src/follow_refs/builder.rs
+++ b/src/follow_refs/builder.rs
@@ -82,7 +82,7 @@ impl<'de, B> BuilderParser for B where B: Builder<'de> {}
 /// on the builder.
 ///
 /// `LivreBuilder` merely defers parsing to the wrapped builder. Its value is in making it
-/// compatible with the rest of the winnow ecosystem.
+/// compatible with the rest of the [`winnow`] ecosystem.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct LivreBuilder<'b, B>(&'b B);
 

--- a/src/follow_refs/from_raw_dict.rs
+++ b/src/follow_refs/from_raw_dict.rs
@@ -4,12 +4,24 @@ use crate::extraction::{extract, RawDict};
 
 use super::{Build, Builder};
 
+/// This awkwardly named trait lets a type define how it can be extracted from a [`RawDict`]
+/// instance. It is a generalisation of the [`FromRawDict`](crate::extraction::FromRawDict)
+/// trait.
+///
+/// This indirection in a type's ability to [`Build`] itself lets us define more complex extraction
+/// strategies, in particular derivable ones. Since a `BuildFromRawDict` type merely pops relevant
+/// keys from a mutable reference to a [`RawDict`], we give more structure to otherwise flat
+/// dictionary structures.
 pub trait BuildFromRawDict<'de>: Sized {
     fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
     where
         B: Builder<'de>;
 }
 
+/// [`BuildFromRawDict`] types are trivially [`Build`]:
+///
+/// 1. Extract the underlying [`RawDict`]
+/// 2. Use it to build the type
 impl<'de, T> Build<'de> for T
 where
     T: BuildFromRawDict<'de>,

--- a/src/follow_refs/mod.rs
+++ b/src/follow_refs/mod.rs
@@ -37,9 +37,19 @@
 //! The difficulty arises when you decide you actually want to get a complete object, rather than
 //! one filled with references that are of no particular value themselves.
 //!
-//! This is what the `Build` trait aims to solve: a mechanism for type to be extracted from
+//! This is what the [`Build`] trait aims to solve: a mechanism for type to be extracted from
 //! a PDF document, regardless of whether some fields may be represented as references in the
 //! serialisation.
+//!
+//! ## Livre's solution
+//!
+//! To do that, Livre provides a separate trait, [`Builder`], which describes types that have the
+//! ability to "follow" a reference and instantiate the underlying object. We can implement
+//! different strategies for a `Builder`, which most likely involve a mapping of some kind to get
+//! from a reference to the relevant data - be that the raw byte stream or some pre-parsed object.
+//!
+//! Beside [`Build`] and [`Builder`], Livre provides the [`BuildFromRawDict`] trait, which helps
+//! define a derivable way of building composite objects (derive macro pending).
 
 mod build;
 mod builder;


### PR DESCRIPTION
This PR modifies the way `Stream`s are extracted/built, by implementing winnow's `Parser` trait for the common sream configuration - which contains the length of the encoded content, in particular.