### PR TITLE
feat: owned builder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
         # enable this ci template to run regardless of whether the lockfile is checked in or not
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
+      - name: cargo clippy --locked
+        run: cargo clippy --locked --all-features --all-targets
       # https://twitter.com/jonhoo/status/1571290371124260865
       - name: cargo test --locked
         run: cargo test --locked --all-features --all-targets -- --include-ignored

--- a/examples/doc.rs
+++ b/examples/doc.rs
@@ -1,4 +1,8 @@
-use livre::{extraction::Extract, follow_refs::Builder, InMemoryDocument};
+use livre::{
+    extraction::{Extract, Object},
+    follow_refs::Builder,
+    InMemoryDocument,
+};
 use winnow::BStr;
 
 fn main() {
@@ -12,7 +16,7 @@ fn main() {
         println!(
             "{:?}: {:?}",
             ref_id,
-            &doc.follow_reference(ref_id).unwrap()[..50]
+            &doc.build_reference::<Object>(ref_id.into()).unwrap()
         )
     }
 

--- a/examples/doc.rs
+++ b/examples/doc.rs
@@ -14,9 +14,9 @@ fn main() {
 
     for &ref_id in doc.xrefs.keys() {
         println!(
-            "{:?}: {:?}",
+            "{:?}\n{:#?}\n\n",
             ref_id,
-            &doc.build_reference::<Object>(ref_id.into()).unwrap()
+            &doc.build_reference::<Object>(ref_id.into())
         )
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -11,7 +11,7 @@ use crate::{
     structure::{ObjectStream, RefLocation, StartXRef, Trailer, XRefTrailerBlock},
 };
 
-impl<'de> Builder for HashMap<ReferenceId, &'de BStr> {
+impl Builder for HashMap<ReferenceId, &BStr> {
     fn build_reference<T>(&self, Reference { id, .. }: Reference<T>) -> PResult<T>
     where
         T: Build,
@@ -41,7 +41,7 @@ pub struct InMemoryDocument<'de> {
     pub xrefs: HashMap<ReferenceId, RefLocation>,
 }
 
-impl<'de> Builder for InMemoryDocument<'de> {
+impl Builder for InMemoryDocument<'_> {
     fn build_reference<T>(&self, Reference { id, .. }: Reference<T>) -> PResult<T>
     where
         T: Build,

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,16 +1,34 @@
 use std::collections::HashMap;
 
-use winnow::BStr;
-
-use crate::{
-    extraction::{extract, Extract, Reference, ReferenceId},
-    follow_refs::Builder,
-    structure::{RefLocation, StartXRef, Trailer, XRefTrailerBlock},
+use winnow::{
+    error::{ContextError, ErrMode},
+    BStr, PResult,
 };
 
-impl<'de> Builder<'de> for HashMap<ReferenceId, &'de BStr> {
-    fn follow_reference(&self, reference_id: ReferenceId) -> Option<&'de BStr> {
-        self.get(&reference_id).copied()
+use crate::{
+    extraction::{extract, Extract, Indirect, Reference, ReferenceId},
+    follow_refs::{Build, Builder, BuilderParser},
+    structure::{ObjectStream, RefLocation, StartXRef, Trailer, XRefTrailerBlock},
+};
+
+impl<'de> Builder for HashMap<ReferenceId, &'de BStr> {
+    fn build_reference<T>(&self, Reference { id, .. }: Reference<T>) -> PResult<T>
+    where
+        T: Build,
+    {
+        let input = &mut self
+            .get(&id)
+            .copied()
+            .ok_or(ErrMode::Cut(ContextError::new()))?;
+
+        let Indirect {
+            id: reference_id,
+            inner,
+        } = Indirect::parse(input, self.as_parser())?;
+
+        debug_assert_eq!(reference_id, id);
+
+        Ok(inner)
     }
 }
 
@@ -20,17 +38,45 @@ pub struct InMemoryDocument<'de> {
     /// The entire input slice
     input: &'de BStr,
     /// The cross-reference table
-    /// TODO: add stream support: some references can be put behind a stream.
     pub xrefs: HashMap<ReferenceId, RefLocation>,
 }
 
-impl<'de> Builder<'de> for InMemoryDocument<'de> {
-    fn follow_reference(&self, reference_id: ReferenceId) -> Option<&'de BStr> {
-        let &offset = self.xrefs.get(&reference_id)?;
+impl<'de> Builder for InMemoryDocument<'de> {
+    fn build_reference<T>(&self, Reference { id, .. }: Reference<T>) -> PResult<T>
+    where
+        T: Build,
+    {
+        let &offset = self
+            .xrefs
+            .get(&id)
+            .ok_or(ErrMode::Backtrack(ContextError::new()))?;
 
         match offset {
-            RefLocation::Plain(offset) => self.input.get(offset..).map(|s| s.as_ref()),
-            _ => todo!("We focus on *vanilla* refs for now."),
+            RefLocation::Plain(offset) => {
+                let input = &mut self
+                    .input
+                    .get(offset..)
+                    .ok_or(ErrMode::Backtrack(ContextError::new()))?
+                    .as_ref();
+
+                let Indirect {
+                    id: reference_id,
+                    inner,
+                } = Indirect::parse(input, self.as_parser())?;
+
+                debug_assert_eq!(reference_id, id);
+
+                Ok(inner)
+            }
+            RefLocation::Compressed {
+                stream_id,
+                // `index` is already contained within the stream.
+                index: _,
+            } => {
+                let stream: ObjectStream =
+                    self.build_reference(ReferenceId::first(stream_id).into())?;
+                stream.build_object(&id, self)
+            }
         }
     }
 }
@@ -73,6 +119,8 @@ impl<'de> Extract<'de> for InMemoryDocument<'de> {
 
             prev = previous;
         }
+
+        println!("{cross_references:?}");
 
         Ok(Self {
             catalog: root,

--- a/src/extraction/mod.rs
+++ b/src/extraction/mod.rs
@@ -21,7 +21,8 @@
 //! ## Derivability
 //!
 //! Through the [`livre_derive`] helper crate, Livre provides (and uses) a derive macro
-//! for [`FromRawDict`], making the derived type [`Extract`].
+//! for [`FromRawDict`], making the derived type indirectly [`Extract`] through a blanket
+//! implementation.
 //!
 //! ## Indirect objects
 //!

--- a/src/extraction/special/map.rs
+++ b/src/extraction/special/map.rs
@@ -85,8 +85,8 @@ impl<'de> RawValue<'de> {
     /// Build the raw value into a strongly typed object.
     pub fn build<T, B>(mut self, builder: &B) -> PResult<T>
     where
-        T: Build<'de>,
-        B: Builder<'de>,
+        T: Build,
+        B: Builder,
     {
         T::build(&mut self.0, builder)
     }
@@ -156,8 +156,8 @@ impl<'de> RawDict<'de> {
 
     pub fn pop_and_build<T, B>(&mut self, key: &Name, builder: &B) -> PResult<Option<T>>
     where
-        T: Build<'de>,
-        B: Builder<'de>,
+        T: Build,
+        B: Builder,
     {
         self.pop(key).map(|value| value.build(builder)).transpose()
     }
@@ -218,10 +218,10 @@ impl FromRawDict<'_> for Nil {
     }
 }
 
-impl<'de> BuildFromRawDict<'de> for Nil {
-    fn build_from_raw_dict<B>(_dict: &mut RawDict<'de>, _builder: &B) -> PResult<Self>
+impl BuildFromRawDict for Nil {
+    fn build_from_raw_dict<'de, B>(_dict: &mut RawDict<'de>, _builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         Ok(Self)
     }

--- a/src/extraction/special/map.rs
+++ b/src/extraction/special/map.rs
@@ -219,7 +219,7 @@ impl FromRawDict<'_> for Nil {
 }
 
 impl BuildFromRawDict for Nil {
-    fn build_from_raw_dict<'de, B>(_dict: &mut RawDict<'de>, _builder: &B) -> PResult<Self>
+    fn build_from_raw_dict<B>(_dict: &mut RawDict<'_>, _builder: &B) -> PResult<Self>
     where
         B: Builder,
     {

--- a/src/extraction/special/name.rs
+++ b/src/extraction/special/name.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, fmt::Debug, ops::Deref};
 use winnow::{
     ascii::hex_uint,
     combinator::{preceded, trace},
+    error::StrContext,
     token::{take, take_till},
     BStr, PResult, Parser,
 };
@@ -52,6 +53,7 @@ impl<'de> Extract<'de> for Name {
                 .map(|name| Self(name.to_vec()))
                 .parse_next(&mut content.as_ref())
         })
+        .context(StrContext::Label("name"))
         .parse_next(input)
     }
 }

--- a/src/extraction/special/object.rs
+++ b/src/extraction/special/object.rs
@@ -36,7 +36,7 @@ pub enum Object {
     Integer(i32),
     Real(f32),
     String(Vec<u8>),
-    Name(Vec<u8>),
+    Name(Name),
     Array(Vec<Object>),
     Dictionary(Map<Object>),
     Stream(Stream<Map<Object>>),
@@ -68,8 +68,8 @@ impl From<LiteralString<'_>> for Object {
 }
 
 impl From<Name> for Object {
-    fn from(Name(inner): Name) -> Self {
-        Self::Name(inner)
+    fn from(value: Name) -> Self {
+        Self::Name(value)
     }
 }
 

--- a/src/extraction/special/object.rs
+++ b/src/extraction/special/object.rs
@@ -206,7 +206,7 @@ mod tests {
     #[case(42, Object::Integer(42))]
     #[case(-42.0, Object::Real(-42.0))]
     #[case("test".to_string(), Object::String("test".into()))]
-    #[case(Name::from("test"), Object::Name(vec![0x74, 0x65, 0x73, 0x74]))]
+    #[case(Name::from("test"), Object::Name([0x74, 0x65, 0x73, 0x74].into()))]
     #[case(vec![0, 0], Object::Array(vec![Object::Integer(0), Object::Integer(0)]))]
     fn into_object<T>(#[case] v: T, #[case] expected: Object)
     where

--- a/src/extraction/special/object.rs
+++ b/src/extraction/special/object.rs
@@ -61,9 +61,9 @@ impl From<f32> for Object {
     }
 }
 
-impl From<LiteralString<'_>> for Object {
+impl From<LiteralString> for Object {
     fn from(LiteralString(inner): LiteralString) -> Self {
-        Self::String(inner.to_vec())
+        Self::String(inner)
     }
 }
 

--- a/src/extraction/special/refs/indirect.rs
+++ b/src/extraction/special/refs/indirect.rs
@@ -7,7 +7,7 @@ use winnow::{
 
 use crate::{
     extraction::{extract, Extract},
-    follow_refs::{Build, BuilderParser},
+    follow_refs::{Build, Builder, BuilderParser},
 };
 
 use super::ReferenceId;
@@ -59,13 +59,13 @@ where
     }
 }
 
-impl<'de, T> Build<'de> for Indirect<T>
+impl<T> Build for Indirect<T>
 where
-    T: Build<'de>,
+    T: Build,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: crate::follow_refs::Builder<'de>,
+        B: Builder,
     {
         Self::parse(input, builder.as_parser())
     }
@@ -86,7 +86,7 @@ mod tests {
     #[case(b"0 0 obj\n10    true\nendobj", Indirect{id: (0, 0).into(), inner: (10i32, true)})]
     fn extraction_and_build<'de, T>(#[case] input: &'de [u8], #[case] expected: Indirect<T>)
     where
-        T: Extract<'de> + Build<'de> + Debug + PartialEq,
+        T: Extract<'de> + Build + Debug + PartialEq,
     {
         let result = extract(&mut input.as_ref()).unwrap();
         assert_eq!(expected, result);

--- a/src/extraction/special/refs/reference.rs
+++ b/src/extraction/special/refs/reference.rs
@@ -8,7 +8,7 @@ use winnow::{
 use super::ReferenceId;
 use crate::{
     extraction::Extract,
-    follow_refs::{Build, BuilderParser},
+    follow_refs::{Build, Builder, BuilderParser},
 };
 
 /// A PDF reference to an *indirect object*.
@@ -97,13 +97,13 @@ where
     }
 }
 
-impl<'de, T> Build<'de> for OptRef<T>
+impl<T> Build for OptRef<T>
 where
-    T: Build<'de>,
+    T: Build,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: crate::follow_refs::Builder<'de>,
+        B: Builder,
     {
         trace(
             "livre-optref",

--- a/src/extraction/special/stream.rs
+++ b/src/extraction/special/stream.rs
@@ -62,10 +62,10 @@ struct StreamDict<T> {
     structured: T,
 }
 
-impl<'de> BuildFromRawDict<'de> for StreamConfig {
-    fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+impl BuildFromRawDict for StreamConfig {
+    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         let Built(length) = dict
             .pop_and_build(&b"Length".into(), builder)?
@@ -82,13 +82,13 @@ impl<'de> BuildFromRawDict<'de> for StreamConfig {
     }
 }
 
-impl<'de, T> BuildFromRawDict<'de> for StreamDict<T>
+impl<T> BuildFromRawDict for StreamDict<T>
 where
-    T: BuildFromRawDict<'de>,
+    T: BuildFromRawDict,
 {
-    fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         let config = StreamConfig::build_from_raw_dict(dict, builder)?;
         let structured = T::build_from_raw_dict(dict, builder)?;
@@ -138,15 +138,15 @@ where
     }
 }
 
-impl<'de, T> Build<'de> for Stream<T>
+impl<T> Build for Stream<T>
 where
-    T: BuildFromRawDict<'de>,
+    T: BuildFromRawDict,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
-        trace("livre-stream", move |i: &mut &'de BStr| {
+        trace("livre-stream", move |i: &mut &BStr| {
             let mut dict: RawDict = extract(i)?;
             let StreamDict {
                 mut config,
@@ -178,10 +178,10 @@ impl Extract<'_> for Stream<()> {
     }
 }
 
-impl<'de> Build<'de> for Stream<()> {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+impl Build for Stream<()> {
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         let Stream {
             structured: Nil,

--- a/src/extraction/special/stream.rs
+++ b/src/extraction/special/stream.rs
@@ -65,7 +65,7 @@ struct StreamDict<T> {
 }
 
 impl BuildFromRawDict for StreamConfig {
-    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    fn build_from_raw_dict<B>(dict: &mut RawDict<'_>, builder: &B) -> PResult<Self>
     where
         B: Builder,
     {
@@ -88,7 +88,7 @@ impl<T> BuildFromRawDict for StreamDict<T>
 where
     T: BuildFromRawDict,
 {
-    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    fn build_from_raw_dict<B>(dict: &mut RawDict<'_>, builder: &B) -> PResult<Self>
     where
         B: Builder,
     {

--- a/src/extraction/special/stream.rs
+++ b/src/extraction/special/stream.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use winnow::{
     ascii::{line_ending, multispace0},
     combinator::{delimited, trace},
@@ -109,10 +111,24 @@ where
 ///
 /// - the structured data, if any
 /// - the actual, decoded content
-#[derive(Debug, PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 pub struct Stream<T> {
     pub structured: T,
     pub content: Vec<u8>,
+}
+
+impl<T> Debug for Stream<T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let utfish = String::from_utf8_lossy(&self.content[..100.min(self.content.len())]);
+
+        f.debug_struct("Stream")
+            .field("structured", &self.structured)
+            .field("content", &utfish)
+            .finish()
+    }
 }
 
 impl<'de, T> Extract<'de> for Stream<T>

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -59,10 +59,10 @@ impl Extract<'_> for Filter {
     }
 }
 
-impl<'de> Build<'de> for Filter {
-    fn build<B>(input: &mut &'_ BStr, _builder: &B) -> PResult<Self>
+impl Build for Filter {
+    fn build<B>(input: &mut &BStr, _builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         extract(input)
     }

--- a/src/filtering.rs
+++ b/src/filtering.rs
@@ -48,6 +48,7 @@ impl Extract<'_> for Filter {
             b"FlateDecode" => Ok(Self::FlateDecode(FlateDecode)),
             b"ASCII85Decode" | b"ASCIIHexDecode" | b"LZWDecode" | b"RunLengthDecode"
             | b"CCITTFaxDecode" | b"JBIG2Decode" | b"DCTDecode" | b"JPXDecode" | b"Crypt" => {
+                return Err(ErrMode::Backtrack(ContextError::new()));
                 todo!(
                     "{} filter is not handled by Livre yet. Consider opening an issue, or better yet, submitting a PR!",
                     // SAFETY: we just matched `value` against an UTF8-encoded string.

--- a/src/follow_refs/build.rs
+++ b/src/follow_refs/build.rs
@@ -21,25 +21,25 @@ use super::{Builder, BuilderParser, Built};
 /// implementation because of the [`OptRef`](crate::extraction::OptRef) type. Moreover,
 /// this would disallow implementing `Build` for [`BuildFromRawDict`](super::BuildFromRawDict),
 /// because the compiler would mark them as competing implementations.
-pub trait Build<'de>: Sized {
+pub trait Build: Sized {
     /// Build an object that rely on a reference, which would be instantiated with the help of the
     /// supplied `builder`.
     ///
     /// The [`Build`] trait, like the [`Extract`](crate::extraction::Extract) trait, is a linear
     /// parser above all, hence we supply an `input`. References found during parsing, if any,
     /// are first parsed as such, and then instantiated by the `builder`.
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>;
+        B: Builder;
 }
 
 macro_rules! impl_build_for_primitive {
     ($($t:ty)+) => {
         $(
-            impl<'de> Build<'de> for $t {
-                fn build<B>(input: &mut &'de BStr, _builder: &B) -> PResult<Self>
+            impl Build for $t {
+                fn build<B>(input: &mut &BStr, _builder: &B) -> PResult<Self>
                 where
-                    B: Builder<'de>,
+                    B: Builder,
                 {
                     extract(input)
                 }
@@ -53,20 +53,20 @@ impl_build_for_primitive!(
   u8 u16 u32 u64 u128 usize
   f32 f64
   bool
-  LiteralString<'de> HexadecimalString
+  HexadecimalString
   Id
   Name
   Object
   Rectangle
 );
 
-impl<'de, T> Build<'de> for Option<T>
+impl<T> Build for Option<T>
 where
-    T: Build<'de>,
+    T: Build,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         alt((
             builder.as_parser().map(|Built(value)| Some(value)),
@@ -76,13 +76,13 @@ where
     }
 }
 
-impl<'de, T> Build<'de> for MaybeArray<T>
+impl<T> Build for MaybeArray<T>
 where
-    T: Build<'de>,
+    T: Build,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         trace(
             "livre-vec",
@@ -96,13 +96,13 @@ where
     }
 }
 
-impl<'de, T> Build<'de> for Vec<T>
+impl<T> Build for Vec<T>
 where
-    T: Build<'de>,
+    T: Build,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         trace(
             "livre-vec",
@@ -119,13 +119,13 @@ where
     }
 }
 
-impl<'de, T, const N: usize> Build<'de> for [T; N]
+impl<T, const N: usize> Build for [T; N]
 where
-    T: Build<'de> + Debug,
+    T: Build + Debug,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         trace(
             concat!("livre-{N}-array"),
@@ -148,16 +148,16 @@ where
 macro_rules! impl_tuple {
     ($len:literal: $first:ident, $($ty:ident),+) => {
         paste!{
-            impl<'de, $first, $($ty),+> Build<'de> for ($first, $($ty),+)
+            impl<$first, $($ty),+> Build for ($first, $($ty),+)
             where
-                $first: Build<'de>,
-                $( $ty: Build<'de>),+
+                $first: Build,
+                $( $ty: Build),+
             {
-                fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+                fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
                 where
-                    B: Builder<'de>,
+                    B: Builder,
                 {
-                    trace(concat!("livre-{}-tuple", $len), move |i: &mut &'de BStr| {
+                    trace(concat!("livre-{}-tuple", $len), move |i: &mut &BStr| {
                         let [<$first:lower>] = $first::build(i, builder)?;
                         $(
                             multispace1(i)?;

--- a/src/follow_refs/build.rs
+++ b/src/follow_refs/build.rs
@@ -53,7 +53,7 @@ impl_build_for_primitive!(
   u8 u16 u32 u64 u128 usize
   f32 f64
   bool
-  HexadecimalString
+  LiteralString HexadecimalString
   Id
   Name
   Object

--- a/src/follow_refs/builder.rs
+++ b/src/follow_refs/builder.rs
@@ -3,7 +3,7 @@ use winnow::{
     BStr, PResult, Parser,
 };
 
-use crate::extraction::{Indirect, Reference, ReferenceId};
+use crate::extraction::Reference;
 
 use super::Build;
 
@@ -71,7 +71,7 @@ pub trait BuilderParser: Sized {
 }
 
 /// Actual implementation of the [`BuilderParser`] trait on [`Builder`].
-impl<'de, B> BuilderParser for B where B: Builder {}
+impl<B> BuilderParser for B where B: Builder {}
 
 /// `LivreBuilder` wraps a generic [`Builder`] type to make it implement [winnow's `Parser`](Parser) trait.
 /// You should not have to create this type yourself. Instead, call [`as_parser`](BuilderParser::as_parser)

--- a/src/follow_refs/from_raw_dict.rs
+++ b/src/follow_refs/from_raw_dict.rs
@@ -1,4 +1,4 @@
-use winnow::PResult;
+use winnow::{BStr, PResult};
 
 use crate::extraction::{extract, RawDict};
 
@@ -12,23 +12,23 @@ use super::{Build, Builder};
 /// strategies, in particular derivable ones. Since a `BuildFromRawDict` type merely pops relevant
 /// keys from a mutable reference to a [`RawDict`], we give more structure to otherwise flat
 /// dictionary structures.
-pub trait BuildFromRawDict<'de>: Sized {
-    fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+pub trait BuildFromRawDict: Sized {
+    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>;
+        B: Builder;
 }
 
 /// [`BuildFromRawDict`] types are trivially [`Build`]:
 ///
 /// 1. Extract the underlying [`RawDict`]
 /// 2. Use it to build the type
-impl<'de, T> Build<'de> for T
+impl<T> Build for T
 where
-    T: BuildFromRawDict<'de>,
+    T: BuildFromRawDict,
 {
-    fn build<B>(input: &mut &'de winnow::BStr, builder: &B) -> winnow::PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> winnow::PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         let mut dict = extract(input)?;
         Self::build_from_raw_dict(&mut dict, builder)

--- a/src/follow_refs/from_raw_dict.rs
+++ b/src/follow_refs/from_raw_dict.rs
@@ -13,7 +13,7 @@ use super::{Build, Builder};
 /// keys from a mutable reference to a [`RawDict`], we give more structure to otherwise flat
 /// dictionary structures.
 pub trait BuildFromRawDict: Sized {
-    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    fn build_from_raw_dict<B>(dict: &mut RawDict<'_>, builder: &B) -> PResult<Self>
     where
         B: Builder;
 }

--- a/src/follow_refs/mod.rs
+++ b/src/follow_refs/mod.rs
@@ -8,7 +8,7 @@
 //! PDF documents resort to a "random-access" architecture to be able to reuse elements and split
 //! complex objects into more atomic subparts. To that end, the PDF body is an enumeration of
 //! "indirect objects", which can be referenced into from other objects. PDF references thus form
-//! a directed acyclic graph (DAG) since referenced object may contain reference themselves.
+//! a directed acyclic graph (DAG) since a referenced object may itself contain references.
 //!
 //! Let's provide an example coming from the specification. In the following snippet, the indirect
 //! object with ID `12 0` contains a string ("Brillig"):

--- a/src/follow_refs/primitive.rs
+++ b/src/follow_refs/primitive.rs
@@ -8,15 +8,15 @@ use super::{Build, Builder, BuilderParser};
 /// associated field may be an reference that should be followed.
 pub struct Built<T>(pub T);
 
-impl<'de, T> Build<'de> for Built<T>
+impl<T> Build for Built<T>
 where
-    T: Build<'de>,
+    T: Build,
 {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
-        trace("livre-built", move |i: &mut &'de BStr| {
+        trace("livre-built", move |i: &mut &BStr| {
             let optref: OptRef<T> = builder.as_parser().parse_next(i)?;
 
             match optref {

--- a/src/structure/object_stream.rs
+++ b/src/structure/object_stream.rs
@@ -136,7 +136,7 @@ struct ObjectStreamDict {
 }
 
 impl BuildFromRawDict for ObjectStreamDict {
-    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+    fn build_from_raw_dict<B>(dict: &mut RawDict<'_>, builder: &B) -> PResult<Self>
     where
         B: Builder,
     {

--- a/src/structure/object_stream.rs
+++ b/src/structure/object_stream.rs
@@ -53,12 +53,12 @@ impl ObjectStream {
     }
 }
 
-impl<'de> ObjectStream {
+impl ObjectStream {
     /// Build an object contained within the `ObjectStream`. Returns an error if the key is absent.
-    pub fn build_object<B, T>(&'de self, reference: &ReferenceId, builder: &B) -> PResult<T>
+    pub fn build_object<B, T>(&self, reference: &ReferenceId, builder: &B) -> PResult<T>
     where
-        T: Build<'de>,
-        B: Builder<'de>,
+        T: Build,
+        B: Builder,
     {
         let mut input = self
             .get_data(reference)
@@ -75,8 +75,8 @@ impl ObjectStream {
     /// instantiate transient objects that cannot be referenced into.
     pub fn build_owned_object<B, T>(&self, reference: &ReferenceId, builder: &B) -> PResult<T>
     where
-        T: for<'de> Build<'de>,
-        B: for<'de> Builder<'de>,
+        T: Build,
+        B: Builder,
     {
         if let Some(mut input) = self.get_data(reference) {
             builder.as_parser().parse_next(&mut input)
@@ -92,12 +92,12 @@ impl ObjectStream {
     }
 }
 
-impl<'de> Build<'de> for ObjectStream {
-    fn build<B>(input: &mut &'de BStr, builder: &B) -> PResult<Self>
+impl Build for ObjectStream {
+    fn build<B>(input: &mut &BStr, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
-        trace("livre-object-stream", move |i: &mut &'de BStr| {
+        trace("livre-object-stream", move |i: &mut &BStr| {
             let Stream {
                 structured: ObjectStreamDict { n, first, extends },
                 content,
@@ -135,10 +135,10 @@ struct ObjectStreamDict {
     pub extends: Option<Reference<ObjectStream>>,
 }
 
-impl<'de> BuildFromRawDict<'de> for ObjectStreamDict {
-    fn build_from_raw_dict<B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
+impl BuildFromRawDict for ObjectStreamDict {
+    fn build_from_raw_dict<'de, B>(dict: &mut RawDict<'de>, builder: &B) -> PResult<Self>
     where
-        B: Builder<'de>,
+        B: Builder,
     {
         let Built(n) = dict
             .pop_and_build(&b"N".into(), builder)?


### PR DESCRIPTION
This PR finalises the work started since the last release to stabilise the `Build` & `Builder` traits, in order to provide a basic, but functional, owned builder type. The main drawback _may_ be its memory inefficiency, and the inability to cache any object.

To lighten the burden put on the `Builder` and avoid tricky issues with lifetimes, this PR also modifies the reference-following traits in a fundamental way: they can only work with owned types. Whether we eventually come back on this decision remains to be decided, but I would like to relax that assumption for now to get a working extraction routine.
Moreover, this decision may even have more fundamental roots. It's not clear to me whether it is even possible to have types that reference the builder at all times.